### PR TITLE
Update using Linux 5.8

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM debian:buster-slim as bpftool-build
+FROM debian:buster-slim
+
+LABEL maintainer "Iago López Galeiras <iago@kinvolk.io>"
+
 ARG KERNEL_REPO=git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 ARG KERNEL_REF=master
 RUN apt-get update && \
@@ -19,26 +22,19 @@ apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
     gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
     bash-completion binutils binutils-dev ca-certificates make git curl \
-    xz-utils gcc pkg-config bison flex build-essential && \
+    xz-utils gcc pkg-config bison flex build-essential zlib1g-dev \
+    python3 libcap-dev clang && \
 apt-get purge --auto-remove && \
 apt-get clean
 
-WORKDIR /tmp
-
 RUN \
+cd /tmp && \
 git clone --depth 1 -b $KERNEL_REF $KERNEL_REPO && \
 cd linux/tools/bpf/bpftool/ && \
-sed -i '/CFLAGS += -O2/a CFLAGS += -static' Makefile && \
-sed -i 's/LIBS = -lelf $(LIBBPF)/LIBS = -lelf -lz $(LIBBPF)/g' Makefile && \
-printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1' >> FEATURES_DUMP.bpftool && \
+printf 'feature-libbfd=0\nfeature-libelf=1\nfeature-bpf=1\nfeature-libelf-mmap=1\nfeature-zlib=1\n' >> FEATURES_DUMP.bpftool && \
 FEATURES_DUMP=`pwd`/FEATURES_DUMP.bpftool make -j `getconf _NPROCESSORS_ONLN` && \
+make -j `getconf _NPROCESSORS_ONLN` && \
 strip bpftool && \
-ldd bpftool 2>&1 | grep -q -e "Not a valid dynamic program" \
-	-e "not a dynamic executable" || \
-	( echo "Error: bpftool is not statically linked"; false ) && \
-mv bpftool /usr/bin && rm -rf /tmp/linux
+mv bpftool /usr/bin && \
+rm -rf /tmp/linux
 
-FROM scratch
-LABEL maintainer "Iago López Galeiras <iago@kinvolk.io>"
-
-COPY --from=bpftool-build /usr/bin/bpftool /bpftool

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -26,7 +26,8 @@ apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
     gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
     bash-completion binutils binutils-dev make git curl \
-    ca-certificates xz-utils gcc pkg-config bison flex build-essential && \
+    ca-certificates xz-utils gcc pkg-config bison flex build-essential \
+    zlib1g-dev python3 && \
 apt-get purge --auto-remove && \
 apt-get clean
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -26,7 +26,8 @@ apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
     gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
     bash-completion binutils binutils-dev make git curl \
-    ca-certificates xz-utils gcc pkg-config bison flex build-essential && \
+    ca-certificates xz-utils gcc pkg-config bison flex build-essential \
+    zlib1g-dev python3 && \
 apt-get purge --auto-remove && \
 apt-get clean
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -7,7 +7,8 @@ apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
     gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
     bash-completion binutils binutils-dev make git curl \
-    ca-certificates xz-utils gcc pkg-config bison flex build-essential && \
+    ca-certificates xz-utils gcc pkg-config bison flex build-essential \
+    zlib1g-dev python3 && \
 apt-get purge --auto-remove && \
 apt-get clean
 


### PR DESCRIPTION
Tested with:
```
export DEFAULTORG=kinvolk
export VERSION=v5.8
make image
docker run -ti --rm --privileged -v /sys/fs/bpf:/sys/fs/bpf kinvolk/bpftool:v5.8-amd64 bpftool map
```

I couldn't make the static link work, so this results in a container image with increased size: 1.25MB -> 575MB.